### PR TITLE
DTPORTAL-17543 Fix audio corruption with UniMRCP quick-fix

### DIFF
--- a/libs/mpf/include/mpf_codec_descriptor.h
+++ b/libs/mpf/include/mpf_codec_descriptor.h
@@ -29,7 +29,7 @@
 APT_BEGIN_EXTERN_C
 
 /** Codec frame time base in msec */
-#define CODEC_FRAME_TIME_BASE 10
+#define CODEC_FRAME_TIME_BASE 20
 /** Bytes per sample for linear pcm */
 #define BYTES_PER_SAMPLE 2
 /** Bits per sample for linear pcm */


### PR DESCRIPTION
Fix the audio corruption issue by addressing the garbage-in / garbage-out problem; make sure that UniMRCP sends data to Asterisk 20ms at a time instead of 10ms at a time.

In the absence of Asterisk's chan_sip driver from properly setting up an RTP smoother / outbound jitter buffer, sending packets 20ms at a time is the next-best thing.

This change will _not_ be submitted to the upstream UniMRCP project because this is not truly the right way to solve this problem – but it gets the job done in the immediate for us.